### PR TITLE
Call `incus admin init` in the action

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -5,7 +5,6 @@ jobs:
       - uses: maxwell-k/setup-incus@main
       - run: |
           set -x
-          incus admin init --auto
           incus launch images:debian/12/cloud c1
           incus exec c1 -- cloud-init status --wait
           incus exec c1 -- cat /etc/os-release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A GitHub Action which installs and configures [Incus] on a default GitHub-hosted
 runner. This action uses the stable Ubuntu packages from [Zabbly]. An example of
 using this action in [a job] is below:
 
-<!-- embedme .github/workflows/readme.yaml#L2-L11 -->
+<!-- embedme .github/workflows/readme.yaml#L2-L10 -->
 
 ```
 main:
@@ -13,7 +13,6 @@ main:
     - uses: maxwell-k/setup-incus@main
     - run: |
         set -x
-        incus admin init --auto
         incus launch images:debian/12/cloud c1
         incus exec c1 -- cloud-init status --wait
         incus exec c1 -- cat /etc/os-release

--- a/action.yaml
+++ b/action.yaml
@@ -78,6 +78,8 @@ runs:
           /usr/lib/systemd/system/incus.socket
         sudo systemctl daemon-reload
         sudo systemctl restart incus.socket
+        incus admin waitready
+        incus admin init --auto
         incus --version
 
 # vim: set filetype=yaml.action :


### PR DESCRIPTION
So that there is no need to call it in every repository that uses the
action.

See also
https://github.com/canonical/setup-lxd/blob/main/action.yml#L38
